### PR TITLE
Fix: Resolve backend migration error in Docker build

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,6 +3,7 @@ FROM rust:1.78-slim-bookworm AS builder
 WORKDIR /app
 
 COPY Cargo.toml Cargo.lock ./
+COPY migration ./migration
 
 RUN cargo build --release
 


### PR DESCRIPTION
## 概要
Fixes the backend migration error by copying the migration directory to the backend Dockerfile.

## Issue
- close #23

## その他
- None