### PR TITLE
Fix: Update rust version to 1.81 in backend Dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.79-slim-bookworm AS builder
+FROM rust:1.81-slim-bookworm AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
## 概要
Updates the rust version in the backend Dockerfile to 1.81.

## Issue
- close #23

## その他
- None