### PR TITLE
Fix: Docker Compose backend-frontend connection issue

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       - "5151:5151"
     environment:
       - RUST_LOG=info
+26	      - HOST=0.0.0.0
       - DATABASE_URL=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
     depends_on:
       db:


### PR DESCRIPTION
Fixes #29: Sets the backend to listen on all interfaces to allow the frontend to connect properly.