### PR TITLE
Fix indentation error in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,8 @@ services:
       - "5151:5151"
     environment:
       - RUST_LOG=info
-26	      - HOST=0.0.0.0
+      - HOST=0.0.0.0
+
       - DATABASE_URL=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
     depends_on:
       db:

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -98,7 +98,7 @@ class ApiClient {
     this.token = token;
   }
 
-  private async request<T>(
+  public async request<T>(
     endpoint: string,
     options: RequestInit = {}
   ): Promise<T> {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -98,7 +98,7 @@ class ApiClient {
     this.token = token;
   }
 
-  public async request<T>(
+  private async request<T>(
     endpoint: string,
     options: RequestInit = {}
   ): Promise<T> {


### PR DESCRIPTION
Fixes indentation error in docker-compose.yml. This was causing the docker-compose build command to fail. Fixes #29